### PR TITLE
5 refactors (no functional change)

### DIFF
--- a/src/codegen.nim
+++ b/src/codegen.nim
@@ -828,7 +828,7 @@ proc renderDeviceConsts(dev: SvdDevice, codegenSymbols: var HashSet[string], out
 
     for (k, v) in cpuConsts:
       outf.writeLine fmt"const {k}* = {v}"
-      codeGenSymbols.incl k
+      codegenSymbols.incl k
 
 proc renderCoreModule(dev: SvdDevice, devFileName: string) =
   const coreBindings = {
@@ -899,14 +899,14 @@ proc renderPeripheralRegAccessors(dev: SvdDevice, codegenSymbols: var HashSet[st
       typedefs.add def
     renderDistinctTypes(typedefs, outf)
 
-    for (name, en) in createFieldEnums(p, typeMap, codeGenSymbols).pairs:
+    for (name, en) in createFieldEnums(p, typeMap, codegenSymbols).pairs:
       if name in enumDefs:
         continue
       enumDefs.incl name
       codegenSymbols.incl en.name
       renderEnum(en, outf)
 
-    for (name, acc) in createAccessors(p, typeMap, codeGenSymbols).pairs:
+    for (name, acc) in createAccessors(p, typeMap, codegenSymbols).pairs:
       if name in accDefs:
         continue
       accDefs.incl name

--- a/src/codegen.nim
+++ b/src/codegen.nim
@@ -874,6 +874,13 @@ proc renderPeripheralRegTypeDefs(dev: SvdDevice, codegenSymbols: var HashSet[str
     outf.writeLine("")
 
 
+proc renderPeripheralInstances(dev: SvdDevice, codegenSymbols: var HashSet[string], typeMap: Table[SvdId, string], outf: File) =
+  renderHeader("# Peripheral object instances", outf)
+  for periph in dev.peripherals.values:
+    let constName = renderPeripheral(periph, typeMap, dev, outf)
+    codegenSymbols.incl constName
+
+
 proc renderDevice*(dev: SvdDevice, dirpath: string) =
   let
     outFileName = dirPath / dev.metadata.name.toLower() & ".nim"
@@ -890,11 +897,8 @@ proc renderDevice*(dev: SvdDevice, dirpath: string) =
 
   let typeMap = dev.buildTypeMap
 
-  renderHeader("# Peripheral object instances", outf)
-  for periph in dev.peripherals.values:
-    let constName = renderPeripheral(periph, typeMap, dev, outf)
-    codegenSymbols.incl constName
   renderPeripheralRegTypeDefs(dev, codegenSymbols, typemap, outf)
+  renderPeripheralInstances(dev, codegenSymbols, typemap, outf)
 
   renderHeader("# Accessors for peripheral registers", outf)
 


### PR DESCRIPTION
renderDevice() was kind of long and had mixed levels of abstraction.  Four commits in this PR are individual extract-to-function refactors that move code out of renderDevice() to their own function.

The last commit simply changes capitalization of a variable to be the same throughout the file.  Nim ignores capitalization, but my editor does not and I was previously unable to jump-to-definition.

There should be no functional change to the code after these commits.

Since this is a stylistic and not a functional change, your tastes may vary.  However, these changes help two upcoming changes in the next PR (1 using the defer statement to close outf in case of an exception) and (2 add a renderAutogenHeader proc that renders meta information about the SVD file as comments at the top of the Nim output).