### PR TITLE
Generate a read proc with a static reg arg

### DIFF
--- a/src/codegen.nim
+++ b/src/codegen.nim
@@ -565,6 +565,18 @@ func createAccessors(
       reader.body = fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
       result[fmt"read[{regTypeName}]"] = reader
 
+      reader =
+        CodeGenProcDef(
+          keyword: "proc",
+          name: "read",
+          public: true,
+          args: @[("reg", fmt"static {regTypeName}")],
+          retType: valType,
+          pragma: @["inline"],
+        )
+      reader.body = fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
+      result[fmt"readStatic[{regTypeName}]"] = reader
+
     if props.access.isWritable:
       var
         writer =

--- a/src/codegen.nim
+++ b/src/codegen.nim
@@ -552,30 +552,28 @@ func createAccessors(
       valType = getRegValueType(reg, regTypeName)
 
     if props.access.isReadable:
-      var
-        reader =
-          CodeGenProcDef(
-            keyword: "proc",
-            name: "read",
-            public: true,
-            args: @[("reg", regTypeName)],
-            retType: valType,
-            pragma: @["inline"],
-          )
-      reader.body = fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
-      result[fmt"read[{regTypeName}]"] = reader
+      # Create regular read accessor
+      result[fmt"read[{regTypeName}]"] = CodeGenProcDef(
+        keyword: "proc",
+        name: "read",
+        public: true,
+        args: @[("reg", regTypeName)],
+        retType: valType,
+        pragma: @["inline"],
+        body: fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
+      )
 
-      reader =
-        CodeGenProcDef(
-          keyword: "proc",
-          name: "read",
-          public: true,
-          args: @[("reg", fmt"static {regTypeName}")],
-          retType: valType,
-          pragma: @["inline"],
-        )
-      reader.body = fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
-      result[fmt"readStatic[{regTypeName}]"] = reader
+      # Create static read accessor, generates more efficient code when possible
+      # See https://github.com/dwhall/nimbed/wiki/svd2nim-analysis#item-3-static-register-parameters
+      result[fmt"read[static {regTypeName}]"] = CodeGenProcDef(
+        keyword: "proc",
+        name: "read",
+        public: true,
+        args: @[("reg", fmt"static {regTypeName}")],
+        retType: valType,
+        pragma: @["inline"],
+        body: fmt"volatileLoad(cast[ptr {valType}](reg.loc))"
+      )
 
     if props.access.isWritable:
       var


### PR DESCRIPTION
The static register argument to the read() proc allows Nim to optimize
 the code and the result is faster execution.  To use this feature,
the calling Nim source code must be of the form:

  var regval = PERIPHERAL.REGISTER.read()

or

  const reg = PERIPHERAL.REGISTER
  var regval = reg.read()

The following calling conventions will use the legacy read() that will not be optimized:

  let reg = PERIPHERAL.REGISTER
  var regval = reg.read()

  var reg = PERIPHERAL.REGISTER
  var regval = reg.read()